### PR TITLE
Add Flair 300

### DIFF
--- a/esphome/brink.yaml
+++ b/esphome/brink.yaml
@@ -23,7 +23,8 @@ packages:
              esphome/sensors/sensor-brink_hum_sensor.yaml,
              esphome/sensors/sensor-brink_co2_1_sensor.yaml
            ]
-    ## options are: 
+    ## options are:
+      # esphome/type/.brink-300.yaml
       # esphome/type/.brink-325.yaml
       # esphome/type/.brink-400.yaml
       # esphome/type/.brink-450.yaml

--- a/esphome/type/brink-300.yaml
+++ b/esphome/type/brink-300.yaml
@@ -1,0 +1,64 @@
+number:
+# Maximum value for Flair 300 is 300m3/h
+  - id: brink_modbus_flow_rate
+    name: "${name} ${brink_modbus_flow_rate}"
+    platform: modbus_controller
+    modbus_controller_id: ${name}
+    register_type: holding
+    address: 8002
+    value_type: S_WORD
+    min_value: 0
+    max_value: 300
+    mode: slider
+
+  - id: brink_flow_0
+    name: "${name} Flow 0"
+    platform: modbus_controller
+    modbus_controller_id: ${name}
+    register_type: holding
+    address: 6000
+    unit_of_measurement: "m3/h"
+    value_type: S_WORD
+    min_value: 0
+    max_value: 300
+    mode: slider
+    icon: mdi:fan-auto
+
+  - id: brink_flow_1
+    name: "${name} Flow 1"
+    platform: modbus_controller
+    modbus_controller_id: ${name}
+    register_type: holding
+    address: 6001
+    unit_of_measurement: "m3/h"
+    value_type: S_WORD
+    min_value: 50
+    max_value: 300
+    mode: slider
+    icon: mdi:fan-speed-1
+
+  - id: brink_flow_2
+    name: "${name} Flow 2"
+    platform: modbus_controller
+    modbus_controller_id: ${name}
+    register_type: holding
+    address: 6002
+    unit_of_measurement: "m3/h"
+    value_type: S_WORD
+    min_value: 50
+    max_value: 300
+    mode: slider
+    icon: mdi:fan-speed-2
+
+  - id: brink_flow_3
+    name: "${name} Flow 3"
+    platform: modbus_controller
+    modbus_controller_id: ${name}
+    register_type: holding
+    address: 6003
+    unit_of_measurement: "m3/h"
+    value_type: S_WORD
+    min_value: 50
+    max_value: 300
+    mode: slider
+    icon: mdi:fan-speed-3


### PR DESCRIPTION
Based on `brink-400.yaml`. Set limit to 300m3/h.

I tested that it shows the correct values for brink Flow 0 - 3.

Not sure what `brink_modbus_flow_rate` is supposed to do when you change the value, so that change is untested. But settings its `max_value` to `300` seems reasonable.