### PR TITLE
Refactor Select - warning: 'esphome::select::Select::state' is deprecated: Use current_option() instead of .state

### DIFF
--- a/esphome/.brink.base.yaml
+++ b/esphome/.brink.base.yaml
@@ -552,7 +552,7 @@ select:
                 return;
               }
 
-              std::string current_mode_str = id(brink_bypass_mode).state;
+              std::string current_mode_str = id(brink_bypass_mode).current_option();
               std::string requested_mode_str = x;  // 'x' is the requested mode value
 
               // Convert strings to integers using the options map


### PR DESCRIPTION
Refactor Select - warning: 'esphome::select::Select::state' is deprecated: Use current_option() instead of .state. 

Will be removed in 2026.7.0