### PR TITLE
Add optional pre-/post-heater control (closes #16)

### DIFF
--- a/esphome/brink.yaml
+++ b/esphome/brink.yaml
@@ -55,6 +55,7 @@ packages:
       # esphome/sensors/sensor-brink_co2_2_sensor.yaml
       # esphome/sensors/sensor-brink_co2_3_sensor.yaml
       # esphome/sensors/sensor-brink_co2_4_sensor.yaml
+      # esphome/features/feature-postheater.yaml  # uncomment if a pre- or post-heater is installed
 
 # for developing/testing, uncomment local includes and comment out remote_package part.
 # packages:

--- a/esphome/features/feature-postheater.yaml
+++ b/esphome/features/feature-postheater.yaml
@@ -1,0 +1,35 @@
+# Optional feature: external heater (pre- or post-heater)
+# Include this package only if your Brink Flair has a heater installed.
+# Register 6130 selects what is installed (none/pre/post),
+# register 6131 is the setpoint that applies when a heater is active.
+# Writing to 6131 while 6130 = 0 may be rejected by the device (Modbus exception 3).
+
+select:
+  - id: brink_heater_mode
+    name: ${brink_heater_mode}
+    platform: modbus_controller
+    modbus_controller_id: ${name}
+    address: 6130
+    value_type: S_WORD
+    skip_updates: 20
+    optionsmap:
+      ${heater_none}: 0
+      ${heater_pre}:  1
+      ${heater_post}: 2
+    icon: mdi:radiator
+
+number:
+  - id: brink_heater_setpoint
+    name: ${brink_heater_setpoint}
+    platform: modbus_controller
+    modbus_controller_id: ${name}
+    register_type: holding
+    address: 6131
+    value_type: S_WORD
+    min_value: 15
+    max_value: 30
+    step: 0.5
+    multiply: 10
+    unit_of_measurement: "°C"
+    mode: slider
+    icon: mdi:thermometer

--- a/esphome/labels/.brink-labels-de.yaml
+++ b/esphome/labels/.brink-labels-de.yaml
@@ -55,6 +55,11 @@ substitutions:
   brink_pressure_from_inside: Abluft Druck
   brink_performance: Performance
   brink_relay: Relay
+  brink_heater_mode: Heizung Modus
+  brink_heater_setpoint: Heizung Solltemperatur
+  heater_none: Nicht verfügbar
+  heater_pre: Vorheizer
+  heater_post: Nachheizer
   auto: Auto
   initialize: Initialisieren...
   unknown: Unbekannt

--- a/esphome/labels/.brink-labels-en.yaml
+++ b/esphome/labels/.brink-labels-en.yaml
@@ -55,6 +55,11 @@ substitutions:
   brink_pressure_from_inside: Atm. pressure from inside
   brink_performance: Performance
   brink_relay: Relay
+  brink_heater_mode: Heater mode
+  brink_heater_setpoint: Heater setpoint
+  heater_none: Not available
+  heater_pre: Pre-heater
+  heater_post: Post-heater
   auto: Auto
   initialize: Initialize
   unknown: Unknown

--- a/esphome/labels/.brink-labels-nl.yaml
+++ b/esphome/labels/.brink-labels-nl.yaml
@@ -55,6 +55,11 @@ substitutions:
   brink_pressure_from_inside: Binnen aanzuig atm. druk
   brink_performance: Rendement
   brink_relay: Relais
+  brink_heater_mode: Heater modus
+  brink_heater_setpoint: Heater instelpunt
+  heater_none: Niet aanwezig
+  heater_pre: Voorverwarmer
+  heater_post: Naverwarmer
   auto: Auto
   initialize: Initialisatie
   unknown: Onbekend


### PR DESCRIPTION
**Add optional pre-/post-heater support (register 6130/6131)**

Introduces a new optional feature package esphome/features/feature-postheater.yaml
that exposes the external heater mode (register 6130: none/pre/post) and the
heater setpoint (register 6131, 15-30 °C in 0.5 °C steps).

Not all Flair units have a heater installed, so the package is opt-in via the
existing packages.files mechanism in brink.yaml. Labels are added in en/de/nl.

Closes #16




## Summary
- Adds a new optional feature package `esphome/features/feature-postheater.yaml`
  for units with a pre- or post-heater installed.
- Exposes register **6130** as a select (`Not available` / `Pre-heater` / `Post-heater`)
  and register **6131** as a setpoint slider (15-30 °C, 0.5 °C steps, `multiply: 10`,
  signed word), matching the ranges in the Brink Modbus UWA2-B/UWA2-E manual.
- Opt-in via `packages.files` in `brink.yaml`, same pattern as the optional
  CO2/humidity sensor packages. Users without a heater simply leave the line
  commented out.
- Labels added in `.brink-labels-en.yaml`, `.brink-labels-de.yaml`,
  `.brink-labels-nl.yaml`.

## Notes
- I do not have a heater installed and cannot verify on real hardware. Anyone
  with a heater please confirm before merging.
- Register 6131 likely behaves like 8002 (flow rate): the device may reject
  writes with Modbus exception 3 while 6130 is set to `Not available`. If that
  turns out to be the case, set the heater mode first, then the setpoint -
  same workaround as for the flow rate / control mode pair.

## How to use
In your `brink.yaml`, uncomment the heater line in `packages.files`:
   ```yaml
   files: [ ...,
            esphome/features/feature-postheater.yaml,
            ... ]